### PR TITLE
increase scanning range from 1km to 5km

### DIFF
--- a/backend/src/main/java/click/snekhome/backend/service/GooglePlacesService.java
+++ b/backend/src/main/java/click/snekhome/backend/service/GooglePlacesService.java
@@ -20,7 +20,7 @@ public class GooglePlacesService {
 
     @Value("${google.api.url}")
     private String baseUrl;
-    private static final String RADIUS = "radius=1000";
+    private static final String RADIUS = "radius=5000";
     private final OkHttpClient client;
 
     public GooglePlacesService() {


### PR DESCRIPTION
# Motivation
In rural areas a scanning range of 1km might not yield any nodes making the player lose interest.

# Implementation
Increased the scanning range to 5km.

# Testing
Awaiting player feedback.
